### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/sample/src/main/java/com/thefinestartist/ytpa/sample/AdHelper.java
+++ b/sample/src/main/java/com/thefinestartist/ytpa/sample/AdHelper.java
@@ -13,6 +13,9 @@ import com.google.android.gms.ads.InterstitialAd;
  */
 public class AdHelper {
 
+    private static InterstitialAd interstitial = null;
+    private static final Object lock = new Object();
+
     public static void loadBannerAd(AdView adView) {
         try {
             adView.loadAd(new AdRequest.Builder()
@@ -26,9 +29,6 @@ public class AdHelper {
             Crashlytics.logException(e);
         }
     }
-
-    private static InterstitialAd interstitial = null;
-    private static final Object lock = new Object();
 
     private static InterstitialAd getInstance(final Context context) {
         synchronized (lock) {

--- a/sample/src/main/java/com/thefinestartist/ytpa/sample/MainActivity.java
+++ b/sample/src/main/java/com/thefinestartist/ytpa/sample/MainActivity.java
@@ -53,6 +53,7 @@ public class MainActivity extends AppCompatActivity {
     Orientation orientation;
     boolean showAudioUi;
     boolean showFadeAnim;
+    private boolean advertised = false;
 
     private static String VIDEO_ID = "iS1g8G_njx8";
 
@@ -188,10 +189,6 @@ public class MainActivity extends AppCompatActivity {
             names[i] = states[i].name();
         return names;
     }
-
-
-    private boolean advertised = false;
-
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed